### PR TITLE
Integrate JSHint for Static Code Analysis

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,9 @@
+{
+  "esversion": 9,
+  "undef": true,
+  "unused": true,
+  "node": true,
+  "globals": {
+    "MY_GLOBAL": true
+  }
+}

--- a/jshint-output.txt
+++ b/jshint-output.txt
@@ -1,0 +1,71 @@
+src/api/users.js: line 707, col 33, Confusing use of '!'.
+
+src/categories/watch.js: line 15, col 13, Confusing use of '!'.
+src/categories/watch.js: line 23, col 13, Confusing use of '!'.
+
+src/controllers/accounts/chats.js: line 104, col 9, Confusing use of '!'.
+
+src/controllers/errors.js: line 43, col 67, 'next' is defined but never used.
+
+src/controllers/helpers.js: line 486, col 75, Expected a 'break' statement before 'case'.
+
+src/database/mongo/sorted/intersect.js: line 143, col 67, Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (module)
+
+src/database/redis/connection.js: line 42, col 13, Confusing use of '!'.
+
+src/flags.js: line 870, col 17, Confusing use of '!'.
+
+src/groups/ownership.js: line 10, col 13, Confusing use of '!'.
+
+src/messaging/rooms.js: line 236, col 13, Confusing use of '!'.
+
+src/messaging/unread.js: line 8, col 13, Confusing use of '!'.
+
+src/meta/configs.js: line 191, col 13, Confusing use of '!'.
+
+src/notifications.js: line 332, col 9, Confusing use of '!'.
+src/notifications.js: line 349, col 49, Confusing use of '!'.
+
+src/privileges/helpers.js: line 195, col 22, Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (privileges)
+
+src/request.js: line 11, col 21, 'fetch' is not defined.
+src/request.js: line 13, col 33, 'fetch' is not defined.
+src/request.js: line 26, col 23, 'AbortSignal' is not defined.
+
+src/routes/write/users.js: line 11, col 10, 'guestRoutes' is defined but never used.
+
+src/socket.io/categories.js: line 145, col 31, Confusing use of '!'.
+
+src/socket.io/modules.js: line 115, col 9, Confusing use of '!'.
+
+src/topics/follow.js: line 38, col 13, Confusing use of '!'.
+
+src/topics/tags.js: line 599, col 13, Confusing use of '!'.
+src/topics/tags.js: line 611, col 13, Confusing use of '!'.
+
+src/topics/unread.js: line 205, col 13, Confusing use of '!'.
+src/topics/unread.js: line 261, col 45, Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (params)
+src/topics/unread.js: line 352, col 13, Confusing use of '!'.
+
+src/user/admin.js: line 16, col 13, Confusing use of '!'.
+
+src/user/auth.js: line 15, col 13, Confusing use of '!'.
+src/user/auth.js: line 41, col 13, Confusing use of '!'.
+src/user/auth.js: line 103, col 13, Confusing use of '!'.
+
+src/user/categories.js: line 11, col 13, Confusing use of '!'.
+src/user/categories.js: line 27, col 13, Confusing use of '!'.
+src/user/categories.js: line 37, col 13, Confusing use of '!'.
+src/user/categories.js: line 49, col 13, Confusing use of '!'.
+src/user/categories.js: line 64, col 13, Confusing use of '!'.
+
+src/user/email.js: line 218, col 9, Confusing use of '!'.
+
+src/user/index.js: line 173, col 9, Confusing use of '!'.
+
+src/user/online.js: line 10, col 13, Confusing use of '!'.
+src/user/online.js: line 22, col 13, Confusing use of '!'.
+
+src/user/posts.js: line 133, col 33, Confusing use of '!'.
+
+42 errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
                 "grunt-contrib-watch": "1.1.0",
                 "husky": "8.0.3",
                 "jsdom": "24.0.0",
+                "jshint": "^2.13.6",
                 "lint-staged": "15.2.2",
                 "mocha": "^10.4.0",
                 "mocha-lcov-reporter": "1.3.0",
@@ -3676,6 +3677,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+            "integrity": "sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==",
+            "dev": true,
+            "dependencies": {
+                "exit": "0.1.2",
+                "glob": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=0.2.5"
+            }
+        },
         "node_modules/cli-cursor": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3770,6 +3784,27 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/cli/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/clipboard": {
@@ -4275,6 +4310,15 @@
                 "express-session": ">=1"
             }
         },
+        "node_modules/console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
+            "dev": true,
+            "dependencies": {
+                "date-now": "^0.1.4"
+            }
+        },
         "node_modules/content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -4715,6 +4759,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==",
+            "dev": true
         },
         "node_modules/dateformat": {
             "version": "4.6.3",
@@ -9026,6 +9076,147 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jshint": {
+            "version": "2.13.6",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.6.tgz",
+            "integrity": "sha512-IVdB4G0NTTeQZrBoM8C5JFVLjV2KtZ9APgybDA1MK73xb09qFs0jCXyQLnCOp1cSZZZbvhq/6mfXHUTaDkffuQ==",
+            "dev": true,
+            "dependencies": {
+                "cli": "~1.0.0",
+                "console-browserify": "1.1.x",
+                "exit": "0.1.x",
+                "htmlparser2": "3.8.x",
+                "lodash": "~4.17.21",
+                "minimatch": "~3.0.2",
+                "strip-json-comments": "1.0.x"
+            },
+            "bin": {
+                "jshint": "bin/jshint"
+            }
+        },
+        "node_modules/jshint/node_modules/dom-serializer": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+            "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/jshint/node_modules/dom-serializer/node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
+        },
+        "node_modules/jshint/node_modules/dom-serializer/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/jshint/node_modules/domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "node_modules/jshint/node_modules/domhandler": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+            "integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/jshint/node_modules/domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+            "dev": true,
+            "dependencies": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/jshint/node_modules/entities": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
+            "dev": true
+        },
+        "node_modules/jshint/node_modules/htmlparser2": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+            "integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "1",
+                "domhandler": "2.3",
+                "domutils": "1.5",
+                "entities": "1.0",
+                "readable-stream": "1.1"
+            }
+        },
+        "node_modules/jshint/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+            "dev": true
+        },
+        "node_modules/jshint/node_modules/minimatch": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/jshint/node_modules/readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/jshint/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+            "dev": true
+        },
+        "node_modules/jshint/node_modules/strip-json-comments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+            "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+            "dev": true,
+            "bin": {
+                "strip-json-comments": "cli.js"
+            },
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
         "grunt-contrib-watch": "1.1.0",
         "husky": "8.0.3",
         "jsdom": "24.0.0",
+        "jshint": "^2.13.6",
         "lint-staged": "15.2.2",
         "mocha": "^10.4.0",
         "mocha-lcov-reporter": "1.3.0",


### PR DESCRIPTION
**Context**
This PR integrates JSHint to improve code quality by catching errors and enforcing best practices.

**Changes**
1. Installed JSHint as a dev dependency
2. Added .jshintrc for linting rules
3. Ran JSHint and saved output to jshint-output.txt

**How to Test**
Run JSHint locally (can start small with npx jshint src/ instead of npx jshint .):
`npx jshint <file-path>`

Example run (jshint-output.txt):
![image](https://github.com/user-attachments/assets/a8a3dc1c-01bb-40f9-aebe-524a7561ba8b)

